### PR TITLE
Continue

### DIFF
--- a/src/actions/navigation.js
+++ b/src/actions/navigation.js
@@ -36,6 +36,10 @@ class Navigation {
   navReverseExpired = () => {
     this._push(routes.reverseExpired);
   };
+
+  navContinue = () => {
+    this._push(routes.zcontinue);
+  };
 }
 
 export default Navigation;

--- a/src/actions/refundActions.js
+++ b/src/actions/refundActions.js
@@ -155,6 +155,44 @@ export const setRefundFromTx = txId => {
   };
 };
 
+export const setRefundLocal = swapData => {
+  return dispatch => {
+    const fileJson = JSON.parse(swapData);
+    fileJson.currency = fileJson.swapInfo.base;
+    fileJson.privateKey = fileJson.swapInfo.keys.privateKey;
+    fileJson.redeemScript = fileJson.swapResponse.redeemScript;
+    fileJson.timeoutBlockHeight = fileJson.swapResponse.timeoutBlockHeight;
+    fileJson.preimageHash = fileJson.swapInfo.preimageHash;
+    fileJson.amount = fileJson.swapResponse.expectedAmount;
+    fileJson.contract = fileJson.swapResponse.address;
+    console.log('setRefundLocal: ', fileJson);
+
+    const verifyFile = verifyRefundFile(fileJson, [
+      'currency',
+      // 'preimageHash',
+      'amount',
+      // 'redeemScript',
+      // 'privateKey',
+      'timeoutBlockHeight',
+      'contract',
+    ]);
+
+    dispatch({
+      type: actionTypes.SET_REFUND_FILE,
+      payload: verifyFile ? fileJson : {},
+    });
+
+    if (fileJson.currency !== 'BTC') {
+      console.log('refundactions.181 setTransactionHash');
+      dispatch({
+        type: actionTypes.SET_REFUND_TXHASH,
+        payload: 'dummyvalue',
+      });
+      setTransactionHash('dummyvalue');
+    }
+  };
+};
+
 export const setTransactionHash = hash => ({
   type: actionTypes.SET_REFUND_TXHASH,
   payload: hash,

--- a/src/actions/reverseActions.js
+++ b/src/actions/reverseActions.js
@@ -125,6 +125,7 @@ export const startReverseSwap = (swapInfo, nextStage, timelockExpired) => {
           `lnswaps_${response?.data?.id}`,
           JSON.stringify({
             type: 'reverse',
+            timestamp: new Date().getTime(),
             swapInfo,
             swapResponse: response.data,
           })

--- a/src/actions/reverseActions.js
+++ b/src/actions/reverseActions.js
@@ -116,6 +116,19 @@ export const startReverseSwap = (swapInfo, nextStage, timelockExpired) => {
         prepayMinerFee: swapInfo.isSponsored,
       })
       .then(response => {
+        // console.log(
+        //   'reverseSwapResponse data swapInfo, swapResponse, ',
+        //   swapInfo,
+        //   response.data
+        // );
+        localStorage.setItem(
+          `lnswaps_${response?.data?.id}`,
+          JSON.stringify({
+            type: 'reverse',
+            swapInfo,
+            swapResponse: response.data,
+          })
+        );
         dispatch(reverseSwapResponse(true, response.data));
 
         // To set "isFetching" to true

--- a/src/actions/swapActions.js
+++ b/src/actions/swapActions.js
@@ -110,7 +110,19 @@ export const startSwap = (swapInfo, cb) => {
     axios
       .post(url, reqobj)
       .then(response => {
-        // console.log('1esponse data ', response.data);
+        // console.log(
+        //   '1esponse data swapInfo, swapResponse, ',
+        //   swapInfo,
+        //   response.data
+        // );
+        localStorage.setItem(
+          `lnswaps_${response?.data?.id}`,
+          JSON.stringify({
+            type: 'swap',
+            swapInfo,
+            swapResponse: response.data,
+          })
+        );
         dispatch(swapResponse(true, response.data));
         // console.log('2response data ', response.data);
         startListening(dispatch, response.data.id, cb);

--- a/src/actions/swapActions.js
+++ b/src/actions/swapActions.js
@@ -208,7 +208,7 @@ const handleSwapStatus = (data, source, dispatch, callback) => {
     case SwapUpdateEvent.InvoicePaid:
     case SwapUpdateEvent.TransactionClaimed:
       if (source) source.close();
-      callback();
+      if (callback) callback();
       break;
 
     case SwapUpdateEvent.TransactionMempool:
@@ -243,7 +243,7 @@ const handleSwapStatus = (data, source, dispatch, callback) => {
         pending: true,
         message: 'Atomic Swap is ready',
       };
-      if (data.transaction && data.transaction.hex) {
+      if (data.transaction) {
         swapStatusObj.transaction = data.transaction;
       }
       dispatch(setSwapStatus(swapStatusObj));

--- a/src/actions/swapActions.js
+++ b/src/actions/swapActions.js
@@ -209,6 +209,13 @@ const handleSwapStatus = (data, source, dispatch, callback) => {
     case SwapUpdateEvent.TransactionClaimed:
       if (source) source.close();
       if (callback) callback();
+      dispatch(
+        setSwapStatus({
+          error: false,
+          pending: false,
+          message: 'Transaction claimed.',
+        })
+      );
       break;
 
     case SwapUpdateEvent.TransactionMempool:

--- a/src/actions/swapActions.js
+++ b/src/actions/swapActions.js
@@ -119,6 +119,7 @@ export const startSwap = (swapInfo, cb) => {
           `lnswaps_${response?.data?.id}`,
           JSON.stringify({
             type: 'swap',
+            timestamp: new Date().getTime(),
             swapInfo,
             swapResponse: response.data,
           })

--- a/src/components/controls/index.js
+++ b/src/components/controls/index.js
@@ -85,7 +85,7 @@ const Controls = ({
 }) => {
   const loadingStyleSelect = loadingStyle ? loadingStyle : classes.text;
   const loadingTextSelect = loadingText ? loadingText : text;
-  // console.log('loading: ', loadingText, loading, loadingRender);
+  // console.log('controls.88 loading: ', loadingText, loading, loadingRender);
   // console.log('text, errorText: ', text, errorText);
   // console.log(
   //   'error, errorText, errorRender, errorAction: ',
@@ -98,7 +98,7 @@ const Controls = ({
   if (swapResponse?.id) swapId = swapResponse.id;
   if (refundFile?.swapResponse?.id) swapId = refundFile?.swapResponse?.id;
   // console.log(
-  //   'controls swapId, swapResponse, destinationAddress ',
+  //   'controls.101 swapId, swapResponse, destinationAddress ',
   //   swapId,
   //   swapResponse,
   //   destinationAddress,

--- a/src/components/navigationbar/newdesktopnavigationbar.js
+++ b/src/components/navigationbar/newdesktopnavigationbar.js
@@ -24,7 +24,7 @@ import { Apps } from '@mui/icons-material';
 // boltz_logo
 const boltz_logo = require('../../asset/icons/logonobg.png');
 
-const pages = ['Swap', 'Refund', 'FAQ'];
+const pages = ['Swap', 'Refund', 'Continue', 'FAQ'];
 // const settings = ['Profile', 'Account', 'Dashboard', 'Logout'];
 
 const DeskTopNavigationBar = ({ classes }) => {
@@ -53,6 +53,10 @@ const DeskTopNavigationBar = ({ classes }) => {
 
       case 'Refund':
         navigation.navRefund();
+        break;
+
+      case 'Continue':
+        navigation.navContinue();
         break;
 
       case 'FAQ':

--- a/src/components/stepswizard/controls.js
+++ b/src/components/stepswizard/controls.js
@@ -5,10 +5,17 @@ import View from '../view';
 const Control = props => {
   const { stage, num, render } = props;
   if (stage === num) {
-    // console.log('controls.8 props ', props);
+    console.log('sw/controls.8 props ', props);
     // let zProps = props;
     if (window.location.href.includes('/swap?swapId=') && stage === 1) {
       props.nextStage(2);
+    }
+    if (
+      window.location.href.includes('/swap?swapId=') &&
+      stage === 3 &&
+      props.swapStatus?.message?.includes('Transaction claimed')
+    ) {
+      props.nextStage(1);
     }
     return render(props);
   } else return null;

--- a/src/components/stepswizard/controls.js
+++ b/src/components/stepswizard/controls.js
@@ -5,6 +5,11 @@ import View from '../view';
 const Control = props => {
   const { stage, num, render } = props;
   if (stage === num) {
+    // console.log('controls.8 props ', props);
+    // let zProps = props;
+    if (window.location.href.includes('/swap?swapId=') && stage === 1) {
+      props.nextStage(2);
+    }
     return render(props);
   } else return null;
 };

--- a/src/components/stepswizard/index.js
+++ b/src/components/stepswizard/index.js
@@ -108,10 +108,11 @@ class StepsWizard extends PureComponent {
     return 100 / this.props.range;
   };
 
-  nextStage = () => {
+  nextStage = count => {
+    let increment = count || 1;
     if (this.state.progress !== 100) {
       this.setState(pre => ({
-        stage: pre.stage + 1,
+        stage: pre.stage + increment,
         progress: pre.progress + this.progressInterval,
       }));
     }

--- a/src/components/stepswizard/index.js
+++ b/src/components/stepswizard/index.js
@@ -130,7 +130,7 @@ class StepsWizard extends PureComponent {
   render() {
     const { stage } = this.state;
     const { classes, onExit, range, refundFile } = this.props;
-    console.log('stepwizard stage, range ', stage, range);
+    // console.log('sw/index.133 stepwizard stage, range ', stage, range, this.props);
     if (range === 3) {
       // refund
       steps = ['Start', 'Upload', 'Connect', 'Refund'];

--- a/src/constants/routes/index.js
+++ b/src/constants/routes/index.js
@@ -5,3 +5,4 @@ export const refund = '/refund';
 export const swap = '/swap';
 export const reverseSwap = '/reverseswap';
 export const reverseExpired = '/expired';
+export const zcontinue = '/continue';

--- a/src/views/continue/continuePageDesktop.js
+++ b/src/views/continue/continuePageDesktop.js
@@ -1,0 +1,224 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import injectSheet from 'react-jss';
+import { crypto } from 'bitcoinjs-lib';
+import ReactNotification from 'react-notifications-component';
+import View from '../../components/view';
+// import Button from '../../components/button';
+// import ModalComponent from '../../components/modal';
+import BackGround from '../../components/background';
+import LandingPageWrapper from './landingPageWrapper';
+// import ModalContent from '../../components/modalcontent';
+import { DeskTopSwapTab } from '../../components/swaptab';
+import NavigationBar from '../../components/navigationbar';
+import { bitcoinNetwork, litecoinNetwork } from '../../constants';
+import { generateKeys, randomBytes, navigation } from '../../actions';
+import { getHexString } from '../../utils';
+import 'react-responsive-carousel/lib/styles/carousel.min.css'; // requires a loader
+import { Carousel } from 'react-responsive-carousel';
+import CircularProgress from '@mui/material/CircularProgress';
+
+const boltz_logo = require('../../asset/icons/scuba2.png');
+
+const LandingPageDeskTopContent = ({
+  classes,
+  initSwap,
+  initReverseSwap,
+  fees,
+  rates,
+  limits,
+  currencies,
+  notificationDom,
+  toggleModal,
+  isOpen,
+  webln,
+  warnings,
+  lastSwap,
+}) => {
+  const loading = currencies.length === 0;
+
+  // let ls = await lastSwap();
+  // console.log(`landingpagedesktop.41 `, lastSwap);
+
+  // <View className={classes.infoWrapper}>
+  // <p className={classes.title}>
+  //     LN - SOV bridge is a fork of the excellent<br /> boltz.exchange.
+  //   </p>
+  //   <p className={classes.title}>
+  //     Instant, Account-Free & <br /> Non-Custodial.
+  //   </p>
+  //   <p className={classes.description}>
+  //     Trading <br />
+  //     <b>{`Shouldn't`}</b>
+  //     <br />
+  //     Require
+  //     <br />
+  //     An Account.
+  //   </p>
+  //   <Button text="WHY?" onPress={() => toggleModal()} />
+  //   <ModalComponent isOpen={isOpen} onClose={toggleModal}>
+  //     <ModalContent />
+  //   </ModalComponent>
+  // </View>
+
+  return (
+    <BackGround>
+      <ReactNotification ref={notificationDom} />
+      <NavigationBar />
+      <View className={classes.wrapper}>
+        {loading ? (
+          <View className={classes.loading}>
+            {/* <img alt="logo" src={boltz_logo} className={classes.loadingLogo} />
+            <p className={classes.loadingText}>Loading...</p> */}
+            <CircularProgress />
+          </View>
+        ) : (
+          <DeskTopSwapTab
+            warnings={warnings}
+            onPress={state => {
+              const keys = generateKeys(
+                state.base === 'BTC' ? bitcoinNetwork : litecoinNetwork
+              );
+
+              const preimage = randomBytes(32);
+              // console.log("generated preimage: ", preimage);
+              console.log(
+                'preimage, preimagehash: ',
+                getHexString(preimage),
+                getHexString(crypto.sha256(preimage))
+              );
+
+              if (state.isReverseSwap) {
+                initReverseSwap({
+                  ...state,
+                  keys,
+                  webln,
+                  preimage: getHexString(preimage),
+                  preimageHash: getHexString(crypto.sha256(preimage)),
+                });
+
+                navigation.navReverseSwap();
+              } else {
+                initSwap({
+                  ...state,
+                  keys,
+                  webln,
+                  preimage: getHexString(preimage),
+                  preimageHash: getHexString(crypto.sha256(preimage)),
+                });
+
+                navigation.navSwap();
+              }
+            }}
+            fees={fees}
+            rates={rates}
+            limits={limits}
+            currencies={currencies}
+          />
+        )}
+      </View>
+      <Carousel
+        autoFocus={false}
+        autoPlay={false}
+        showArrows={false}
+        showStatus={false}
+        showIndicators={false}
+        showThumbs={false}
+        className={classes.carousel}
+      >
+        <div>
+          {/* <img src="asset/scuba1.png" /> */}
+          {/* <p className="legend">Previous Swap Details: </p> */}
+          <a
+            href={lastSwap.link}
+            target="_blank"
+            className={classes.carouseltext}
+            rel="noreferrer"
+          >
+            Previous Swap Amount: {lastSwap.amount} STX 🔄
+          </a>
+        </div>
+      </Carousel>
+    </BackGround>
+  );
+};
+
+const styles = theme => ({
+  carouseltext: {
+    color: 'white',
+    textDecoration: 'none',
+  },
+  carousel: {
+    marginBottom: '1em',
+  },
+  wrapper: {
+    flex: '1 0 100%',
+    alignItems: 'center',
+    justifyContent: 'space-around',
+  },
+  infoWrapper: {
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 32,
+    color: '#fff',
+    '@media (min-width: 1500px)': {
+      fontSize: 42,
+    },
+  },
+  description: {
+    fontSize: 32,
+    '@media (min-width: 1500px)': {
+      fontSize: 42,
+    },
+  },
+  loading: {
+    width: '600px',
+    height: '400px',
+    display: 'flex',
+    alignItems: 'center',
+    alignContent: 'center',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    // backgroundColor: '#fff',
+    '@media (min-width: 1500px)': {
+      width: '800px',
+      height: '600px',
+    },
+  },
+  loadingLogo: {
+    width: '200px',
+    height: '200px',
+    display: 'block',
+    marginBottom: '10px',
+  },
+  loadingText: {
+    fontSize: '20px',
+  },
+});
+
+LandingPageDeskTopContent.propTypes = {
+  warnings: PropTypes.array,
+  classes: PropTypes.object.isRequired,
+  initSwap: PropTypes.func.isRequired,
+  initReverseSwap: PropTypes.func.isRequired,
+  notificationDom: PropTypes.object,
+  fees: PropTypes.object.isRequired,
+  rates: PropTypes.object.isRequired,
+  limits: PropTypes.object.isRequired,
+  currencies: PropTypes.array.isRequired,
+  toggleModal: PropTypes.func,
+  isOpen: PropTypes.bool,
+  webln: PropTypes.object,
+  // lastSwap: PropTypes.object,
+};
+
+const LandingPageDeskTop = props => (
+  <LandingPageWrapper {...props}>
+    {p => <LandingPageDeskTopContent {...p} />}
+  </LandingPageWrapper>
+);
+
+export default injectSheet(styles)(LandingPageDeskTop);

--- a/src/views/continue/continuePageDesktop.js
+++ b/src/views/continue/continuePageDesktop.js
@@ -139,9 +139,13 @@ class LandingPageDeskTopContent extends React.Component {
       <BackGround>
         <ReactNotification ref={notificationDom} />
         <NavigationBar />
-        <Typography variant="h3" sx={{ textAlign: 'center', color: 'white' }}>
+        <Typography
+          variant="h4"
+          sx={{ m: 0.5, textAlign: 'center', color: 'white' }}
+        >
           Continue Previous Swaps
         </Typography>
+        <Divider sx={{ m: 2 }} />
         <View className={classes.wrapper}>
           {loading ? (
             <View className={classes.loading}>
@@ -153,7 +157,7 @@ class LandingPageDeskTopContent extends React.Component {
                 this.state.lnswaps.length > 0 ? (
                   <Card
                     variant="outlined"
-                    sx={{ m: 1, width: '100%' }}
+                    sx={{ m: 1 }}
                     key={swap?.swapResponse?.id}
                   >
                     <CardHeader

--- a/src/views/continue/continuePageDesktop.js
+++ b/src/views/continue/continuePageDesktop.js
@@ -20,6 +20,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import Card from '@mui/material/Card';
 import CardActions from '@mui/material/CardActions';
 import CardContent from '@mui/material/CardContent';
+import CardHeader from '@mui/material/CardHeader';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import axios from 'axios';
@@ -79,6 +80,7 @@ class LandingPageDeskTopContent extends React.Component {
             swapData.link = '/swap';
           }
           swapData.link = swapData.link + '?swapId=' + swapId;
+          // TODO: check if preimagehash was refunded before
           console.log('swapId, swapData, status: ', swapId, swapData, status);
           lnswaps.push(swapData);
         }
@@ -142,14 +144,15 @@ class LandingPageDeskTopContent extends React.Component {
                     sx={{ m: 1, width: '100%' }}
                     key={swap?.swapResponse?.id}
                   >
+                    <CardHeader
+                      title={'Swap ID: ' + swap?.swapResponse?.id}
+                      subheader={
+                        swap?.timestamp
+                          ? new Date(swap?.timestamp).toLocaleString()
+                          : ''
+                      }
+                    />
                     <CardContent>
-                      <Typography
-                        sx={{ fontSize: 14 }}
-                        color="text.secondary"
-                        gutterBottom
-                      >
-                        Swap ID: {swap?.swapResponse?.id}
-                      </Typography>
                       <Typography variant="h5" component="div">
                         Status: {swap?.status}
                       </Typography>

--- a/src/views/continue/continuePageDesktop.js
+++ b/src/views/continue/continuePageDesktop.js
@@ -67,16 +67,19 @@ class LandingPageDeskTopContent extends React.Component {
           const swapData = JSON.parse(localStorage[item]);
           const status = await this.getSwapStatus(swapId);
           swapData.status = status;
-          if (status === 'invoice.expired') {
+          if (status === 'invoice.expired' || status === 'swap.expired') {
             swapData.buttonText = 'Failed';
           } else if (status === 'transaction.claimed') {
             swapData.buttonText = 'Finished';
           } else if (status.includes('refund')) {
             swapData.buttonText = 'Refund';
+            swapData.link = '/refund';
           } else {
             swapData.buttonText = 'Continue';
+            swapData.link = '/swap';
           }
-          // console.log('swapId, swapData, status: ', swapId, swapData, status);
+          swapData.link = swapData.link + '?swapId=' + swapId;
+          console.log('swapId, swapData, status: ', swapId, swapData, status);
           lnswaps.push(swapData);
         }
       }
@@ -122,15 +125,16 @@ class LandingPageDeskTopContent extends React.Component {
       <BackGround>
         <ReactNotification ref={notificationDom} />
         <NavigationBar />
+        <Typography variant="h3" sx={{ textAlign: 'center', color: 'white' }}>
+          Continue Previous Swaps
+        </Typography>
         <View className={classes.wrapper}>
           {loading ? (
             <View className={classes.loading}>
-              {/* <img alt="logo" src={boltz_logo} className={classes.loadingLogo} />
-            <p className={classes.loadingText}>Loading...</p> */}
               <CircularProgress />
             </View>
           ) : (
-            <div>
+            <div style={{ maxHeight: '100%' }}>
               {this.state.lnswaps.map(swap =>
                 this.state.lnswaps.length > 0 ? (
                   <Card
@@ -169,6 +173,7 @@ class LandingPageDeskTopContent extends React.Component {
                           swap.buttonText !== 'Continue' &&
                           swap.buttonText !== 'Refund'
                         }
+                        href={swap.link}
                       >
                         {swap.buttonText}
                       </Button>

--- a/src/views/continue/continuePageDesktop.js
+++ b/src/views/continue/continuePageDesktop.js
@@ -47,6 +47,18 @@ const boltz_logo = require('../../asset/icons/scuba2.png');
 // }) => {
 //   const loading = currencies.length === 0;
 
+function status2HumanReadable(str) {
+  // console.log('status2HumanReadable ', str, str.slice(0, 2));
+  if (str.slice(0, 2) === 'as') {
+    // Atomic Swap
+    str = str.replace('as', '⬇️ ');
+  }
+  str = str.replace('.', ' ');
+  return str.replace(/\w\S*/g, function(txt) {
+    return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+  });
+}
+
 class LandingPageDeskTopContent extends React.Component {
   constructor() {
     super();
@@ -80,6 +92,7 @@ class LandingPageDeskTopContent extends React.Component {
           const swapData = JSON.parse(localStorage[item]);
           const status = await this.getSwapStatus(swapId);
           swapData.status = status;
+          swapData.statusText = status2HumanReadable(status);
           if (status === 'invoice.expired' || status === 'swap.expired') {
             swapData.buttonText = 'Failed';
           } else if (status === 'transaction.claimed') {
@@ -171,7 +184,7 @@ class LandingPageDeskTopContent extends React.Component {
                     <Divider />
                     <CardContent>
                       <Typography variant="h5" component="div">
-                        Status: {swap?.status}
+                        Status: {swap?.statusText}
                       </Typography>
                       {/* sx={{ mb: 1.5 }} color="text.secondary" */}
                       <Typography variant="body2">

--- a/src/views/continue/continuePageDesktop.js
+++ b/src/views/continue/continuePageDesktop.js
@@ -64,6 +64,7 @@ class LandingPageDeskTopContent extends React.Component {
     super();
     this.state = {
       lnswaps: [],
+      loadingSwaps: true,
     };
   }
 
@@ -110,7 +111,7 @@ class LandingPageDeskTopContent extends React.Component {
           lnswaps.push(swapData);
         }
       }
-      this.setState({ lnswaps });
+      this.setState({ lnswaps, loadingSwaps: false });
     } catch (error) {
       console.log('error parsing lnswaps: ', error.message);
     }
@@ -160,11 +161,17 @@ class LandingPageDeskTopContent extends React.Component {
         </Typography>
         <Divider sx={{ m: 2 }} />
         <View className={classes.wrapper}>
-          {loading ? (
+          {!this.state.loadingSwaps && this.state.lnswaps.length === 0 ? (
+            <Typography variant="h5" component="div" sx={{ color: 'white' }}>
+              You do not have any previous swaps on this browser yet.
+            </Typography>
+          ) : null}
+          {loading && this.state.loadingSwaps ? (
             <View className={classes.loading}>
               <CircularProgress />
             </View>
-          ) : (
+          ) : null}
+          {this.state.lnswaps.length === 0 ? null : (
             <div style={{ maxHeight: '100%' }}>
               {this.state.lnswaps.map(swap =>
                 this.state.lnswaps.length > 0 ? (
@@ -253,7 +260,7 @@ const styles = () => ({
   },
   wrapper: {
     flex: '1 0 100%',
-    alignItems: 'center',
+    alignItems: 'flex-start',
     justifyContent: 'space-around',
   },
   infoWrapper: {

--- a/src/views/continue/continuePageDesktop.js
+++ b/src/views/continue/continuePageDesktop.js
@@ -23,6 +23,8 @@ import CardContent from '@mui/material/CardContent';
 import CardHeader from '@mui/material/CardHeader';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
+import Tooltip from '@mui/material/Tooltip';
+import Divider from '@mui/material/Divider';
 import axios from 'axios';
 import { boltzApi } from '../../constants';
 
@@ -52,6 +54,16 @@ class LandingPageDeskTopContent extends React.Component {
       lnswaps: [],
     };
   }
+
+  deleteLocalSwap = swapId => {
+    if (!swapId) {
+      console.log('swapId to delete is required.');
+      return;
+    }
+    console.log('removing deleteLocalSwap ', swapId);
+    localStorage.removeItem('lnswaps_' + swapId);
+    window.location.reload();
+  };
 
   componentDidMount = async () => {
     try {
@@ -152,6 +164,7 @@ class LandingPageDeskTopContent extends React.Component {
                           : ''
                       }
                     />
+                    <Divider />
                     <CardContent>
                       <Typography variant="h5" component="div">
                         Status: {swap?.status}
@@ -169,14 +182,29 @@ class LandingPageDeskTopContent extends React.Component {
                         Quote: {swap.swapInfo.quoteAmount} {swap.swapInfo.quote}
                       </Typography>
                     </CardContent>
-                    <CardActions>
+                    <Divider />
+                    <CardActions sx={{ justifyContent: 'flex-end' }}>
+                      <Tooltip title="Swap data will be deleted forever!">
+                        <Button
+                          disabled={swap.buttonText === 'Continue'}
+                          onClick={() =>
+                            this.deleteLocalSwap(swap?.swapResponse?.id)
+                          }
+                          variant="outlined"
+                          color="error"
+                          sx={{ mr: 1 }}
+                        >
+                          Delete
+                        </Button>
+                      </Tooltip>
                       <Button
-                        size="small"
                         disabled={
                           swap.buttonText !== 'Continue' &&
                           swap.buttonText !== 'Refund'
                         }
                         href={swap.link}
+                        variant="contained"
+                        className={classes.stacksButton}
                       >
                         {swap.buttonText}
                       </Button>
@@ -192,7 +220,13 @@ class LandingPageDeskTopContent extends React.Component {
   }
 }
 
-const styles = theme => ({
+const styles = () => ({
+  stacksButton: {
+    backgroundColor: '#7a40ee',
+    backgroundImage: 'linear-gradient(135deg, #5546ff, rgba(122, 64, 238, 0))',
+    webkitTransition: 'background-color 200ms ease-in-out',
+    transition: 'background-color 200ms ease-in-out',
+  },
   carouseltext: {
     color: 'white',
     textDecoration: 'none',

--- a/src/views/continue/index.js
+++ b/src/views/continue/index.js
@@ -1,0 +1,37 @@
+import React, { lazy } from 'react';
+import { connect } from 'react-redux';
+import { initSwap } from '../../actions/swapActions';
+// import PlatformSelector from '../../hoc/platformSelector';
+import * as actions from '../../actions/landingPageActions';
+import { initReverseSwap } from '../../actions/reverseActions';
+
+const LandingPageDesktop = lazy(() => import('./continuePageDesktop'));
+// const LandingPageMobile = lazy(() => import('./landingPageMobile'));
+
+const LandingPage = props => (
+  <LandingPageDesktop {...props} />
+  // <PlatformSelector
+  //   mobile={<LandingPageMobile {...props} />}
+  //   desktop={<LandingPageDesktop {...props} />}
+  // />
+);
+
+const mapStateToProps = state => ({
+  warnings: state.landingpageReducer.warnings,
+  fees: state.landingpageReducer.fees,
+  rates: state.landingpageReducer.rates,
+  limits: state.landingpageReducer.limits,
+  currencies: state.landingpageReducer.currencies,
+  errorMessage: state.landingpageReducer.errorMessage,
+});
+
+const mapDispatchToProps = dispatch => ({
+  initSwap: state => dispatch(initSwap(state)),
+  initReverseSwap: state => dispatch(initReverseSwap(state)),
+  getPairs: () => dispatch(actions.getPairs()),
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(LandingPage);

--- a/src/views/continue/landingPageWrapper.js
+++ b/src/views/continue/landingPageWrapper.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { requestProvider } from 'webln';
+import { notificationData } from '../../utils';
+import { getLastSwap } from '../../actions/landingPageActions';
+
+class LandingPageWrapper extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isOpen: false,
+      lastSwap: {amount: '', link: ''},
+      announcementSet: false,
+      showAnnouncement: false,
+    };
+
+    this.notificationDom = React.createRef();
+  }
+
+  componentDidMount = async () => {
+    this.props.getPairs();
+    requestProvider()
+      .then(provider => {
+        this.webln = provider;
+        this.forceUpdate();
+      })
+      .catch(error => {
+        console.log(`Could not enable WebLN: ${error}`);
+      });
+    
+    let lastSwap = await getLastSwap();
+    // console.log(`landingpagewrapper.30 lastswap `, lastSwap)
+    this.setState({lastSwap: lastSwap})
+    // this.state.lastSwap = await getLastSwap()
+  };
+
+  componentDidUpdate = () => {
+    // if (this.props.errorMessage) {
+    //   this.addNotification(this.props.errorMessage, 0);
+    // }
+    if(this.state.showAnnouncement && !this.state.announcementSet) {
+      // announcement
+      this.notificationDom.current.addNotification(
+        notificationData({
+          title: 'Status Update', 
+          message:'Bridge is temporarily offline until stuck transactions clear from mempool due to recent congestion.\nSorry for the inconvenience.',
+          }, 
+          1, 0));
+      this.setState({announcementSet: true});
+    }
+  };
+
+  addNotification = (info, type) => {
+    this.notificationDom.current.addNotification(notificationData(info, type));
+  };
+
+  toggleModal = () => {
+    this.setState(prev => ({ isOpen: !prev.isOpen }));
+  };
+
+  render() {
+    return this.props.children({
+      ...this.props,
+      isOpen: this.state.isOpen,
+      toggleModal: this.toggleModal,
+      notificationDom: this.notificationDom,
+      webln: this.webln,
+      lastSwap: this.state.lastSwap,
+    });
+  }
+}
+
+LandingPageWrapper.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+  errorMessage: PropTypes.object,
+  getPairs: PropTypes.func.isRequired,
+  classes: PropTypes.object,
+  initSwap: PropTypes.func.isRequired,
+  initReverseSwap: PropTypes.func.isRequired,
+  fees: PropTypes.object.isRequired,
+  rates: PropTypes.object.isRequired,
+  limits: PropTypes.object.isRequired,
+  currencies: PropTypes.array.isRequired,
+  warnings: PropTypes.array.isRequired,
+};
+
+export default LandingPageWrapper;

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -23,6 +23,7 @@ const Swap = lazy(() => import('./swap'));
 const Refund = lazy(() => import('./refund'));
 const ReverseSwap = lazy(() => import('./reverse'));
 const ReverseSwapTimelockExpired = lazy(() => import('./reversetimelock'));
+const Continue = lazy(() => import('./continue'));
 
 // const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
 // prefersDarkMode ? 'dark' : 'light',
@@ -73,6 +74,7 @@ const App = () => {
               <Route exact path={routes.swap} component={Swap} />
               <Route exact path={routes.refund} component={Refund} />
               <Route exact path={routes.reverseSwap} component={ReverseSwap} />
+              <Route exact path={routes.zcontinue} component={Continue} />
               <Route
                 exact
                 path={routes.reverseExpired}

--- a/src/views/refund/index.js
+++ b/src/views/refund/index.js
@@ -21,6 +21,7 @@ const mapDispatchToProps = dispatch => ({
     ),
   completeRefund: () => dispatch(actions.completeRefund()),
   setRefundFromTx: txId => dispatch(actions.setRefundFromTx(txId)),
+  setRefundLocal: swapData => dispatch(actions.setRefundLocal(swapData)),
   // refundStx: (swapInfo, swapResponse) => dispatch(actions.refundStx(swapInfo, swapResponse)),
 });
 

--- a/src/views/refund/refund.js
+++ b/src/views/refund/refund.js
@@ -47,6 +47,7 @@ const Refund = ({
   isFetching,
   setRefundTransactionHash,
   setRefundFromTx,
+  setRefundLocal,
 }) => {
   return (
     <Background>
@@ -75,6 +76,7 @@ const Refund = ({
                   setTransactionHash={setTransactionHash}
                   refundFile={refundFile}
                   setRefundFromTx={setRefundFromTx}
+                  setRefundLocal={setRefundLocal}
                 />
               )}
             />
@@ -174,6 +176,7 @@ Refund.propTypes = {
   refundTransactionHash: PropTypes.string,
   setRefundTransactionHash: PropTypes.func.isRequired,
   setRefundFromTx: PropTypes.func.isRequired,
+  setRefundLocal: PropTypes.func,
 };
 
 export default injectSheet(styles)(Refund);

--- a/src/views/refund/steps/uploadRefundFile.js
+++ b/src/views/refund/steps/uploadRefundFile.js
@@ -58,55 +58,86 @@ const UploadRefundFileStyles = theme => ({
   },
 });
 
-const StyledUploadRefundFile = ({
-  classes,
-  setRefundFile,
-  setTransactionHash,
-  isUploaded,
-  refundFile,
-  setRefundFromTx,
-  // refundStx,
-}) => (
-  <View className={classes.wrapper}>
-    {isUploaded ? (
-      <CheckCircle
-        size={240}
-        style={{ fontSize: 240 }}
-        className={classes.icon}
-        color="success"
-      />
-    ) : (
-      <>
-        <DropZone className={classes.dropZone} onFileRead={setRefundFile}>
-          <p className={classes.info}>Drag the refund.png here</p>
-          {/* <span className={classes.info}>or click to select file</span> */}
-          {/* <FileUpload
+class StyledUploadRefundFile extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      refundSet: false,
+    };
+  }
+
+  setRefundFromLocal = async setRefundLocal => {
+    try {
+      // check if refunding from localstorage
+      if (!window.location.href.includes('?')) return;
+      const swapId = window.location.href.split('?swapId=')[1];
+      if (!localStorage['lnswaps_' + swapId]) return;
+      const swapData = localStorage['lnswaps_' + swapId];
+      console.log('setRefundFromLocal ', setRefundLocal, swapData);
+      setRefundLocal(swapData);
+      this.setState({ refundSet: true });
+    } catch (error) {
+      console.log('error getting swapId: ', error.message);
+    }
+  };
+
+  render() {
+    const {
+      classes,
+      setRefundFile,
+      setTransactionHash,
+      isUploaded,
+      refundFile,
+      setRefundFromTx,
+      setRefundLocal,
+      // refundStx,
+    } = this.props;
+
+    if (!this.state.refundSet) {
+      this.setRefundFromLocal(setRefundLocal);
+    }
+
+    return (
+      <View className={classes.wrapper}>
+        {isUploaded ? (
+          <CheckCircle
+            size={240}
+            style={{ fontSize: 240 }}
+            className={classes.icon}
+            color="success"
+          />
+        ) : (
+          <>
+            <DropZone className={classes.dropZone} onFileRead={setRefundFile}>
+              <p className={classes.info}>Drag the refund.png here</p>
+              {/* <span className={classes.info}>or click to select file</span> */}
+              {/* <FileUpload
             text={'Select file'}
             onFileRead={setRefundFile}
             acceptMimeType={'image/png'}
           /> */}
-          <label htmlFor="icon-button-file">
-            <Input
-              accept="image/*"
-              id="icon-button-file"
-              type="file"
-              // onChange={setRefundFile}
-              onChange={event => {
-                setRefundFile(event.target.files[0]);
-              }}
-              hidden
-              sx={{ display: 'none' }}
-            />
-            <Button
-              variant="contained"
-              color="primary"
-              aria-label="upload picture"
-              component="span"
-              endIcon={<Upload />}
-            >
-              Upload
-            </Button>
-            {/* <IconButton
+              <label htmlFor="icon-button-file">
+                <Input
+                  accept="image/*"
+                  id="icon-button-file"
+                  type="file"
+                  // onChange={setRefundFile}
+                  onChange={event => {
+                    setRefundFile(event.target.files[0]);
+                  }}
+                  hidden
+                  sx={{ display: 'none' }}
+                />
+                <Button
+                  variant="contained"
+                  color="primary"
+                  aria-label="upload picture"
+                  component="span"
+                  endIcon={<Upload />}
+                >
+                  Upload
+                </Button>
+                {/* <IconButton
               color="primary"
               aria-label="upload picture"
               component="span"
@@ -115,38 +146,40 @@ const StyledUploadRefundFile = ({
             >
               <Upload />
             </IconButton> */}
-          </label>
-        </DropZone>
-        <View className={classes.regular}>
-          <p className={`${classes.mobileInfo}`}>
-            (Optional) If you don't have the refund file, paste Stacks lockStx
-            transaction Id
-          </p>
-          <InputArea
-            height={100}
-            width={400}
-            onChange={setRefundFromTx}
-            placeholder={`EG: ${sampleStacksTxId}`}
-          />
-        </View>
-      </>
-    )}
-    {refundFile.currency === 'BTC' ? (
-      <View className={classes.regular}>
-        <p className={`${classes.info} ${classes.mobileInfo}`}>
-          Paste the tx id of the BTC lockup transaction
-        </p>
-        <InputArea
-          height={100}
-          width={400}
-          className={classes.notfullwidth}
-          onChange={setTransactionHash}
-          placeholder={`EG: ${lockupTransactionHash}`}
-        />
+              </label>
+            </DropZone>
+            <View className={classes.regular}>
+              <p className={`${classes.mobileInfo}`}>
+                (Optional) If you don't have the refund file, paste Stacks
+                lockStx transaction Id
+              </p>
+              <InputArea
+                height={100}
+                width={400}
+                onChange={setRefundFromTx}
+                placeholder={`EG: ${sampleStacksTxId}`}
+              />
+            </View>
+          </>
+        )}
+        {refundFile.currency === 'BTC' ? (
+          <View className={classes.regular}>
+            <p className={`${classes.info} ${classes.mobileInfo}`}>
+              Paste the tx id of the BTC lockup transaction
+            </p>
+            <InputArea
+              height={100}
+              width={400}
+              className={classes.notfullwidth}
+              onChange={setTransactionHash}
+              placeholder={`EG: ${lockupTransactionHash}`}
+            />
+          </View>
+        ) : null}
       </View>
-    ) : null}
-  </View>
-);
+    );
+  }
+}
 
 StyledUploadRefundFile.propTypes = {
   classes: PropTypes.object.isRequired,

--- a/src/views/refund/steps/uploadRefundFile.js
+++ b/src/views/refund/steps/uploadRefundFile.js
@@ -73,7 +73,7 @@ class StyledUploadRefundFile extends React.Component {
       const swapId = window.location.href.split('?swapId=')[1];
       if (!localStorage['lnswaps_' + swapId]) return;
       const swapData = localStorage['lnswaps_' + swapId];
-      console.log('setRefundFromLocal ', setRefundLocal, swapData);
+      // console.log('setRefundFromLocal ', setRefundLocal, swapData);
       setRefundLocal(swapData);
       this.setState({ refundSet: true });
     } catch (error) {

--- a/src/views/refund/steps/uploadRefundFile.js
+++ b/src/views/refund/steps/uploadRefundFile.js
@@ -1,16 +1,16 @@
 import React from 'react';
 import injectSheet from 'react-jss';
 import PropTypes from 'prop-types';
-import { FaCheckCircle } from 'react-icons/fa';
+// import { FaCheckCircle } from 'react-icons/fa';
 import View from '../../../components/view';
 import InputArea from '../../../components/inputarea';
 import DropZone from '../../../components/dropzone';
-import FileUpload from '../../../components/fileupload';
+// import FileUpload from '../../../components/fileupload';
 import { lockupTransactionHash, sampleStacksTxId } from '../../../constants';
 import { CheckCircle, Upload } from '@mui/icons-material';
-import { Button, IconButton, Input } from '@mui/material';
+import { Button, Input } from '@mui/material';
 
-const UploadRefundFileStyles = theme => ({
+const UploadRefundFileStyles = () => ({
   notfullwidth: {
     width: '90%',
   },
@@ -150,7 +150,7 @@ class StyledUploadRefundFile extends React.Component {
             </DropZone>
             <View className={classes.regular}>
               <p className={`${classes.mobileInfo}`}>
-                (Optional) If you don't have the refund file, paste Stacks
+                (Optional) If you do not have the refund file, paste Stacks
                 lockStx transaction Id
               </p>
               <InputArea
@@ -187,6 +187,8 @@ StyledUploadRefundFile.propTypes = {
   isUploaded: PropTypes.bool.isRequired,
   setTransactionHash: PropTypes.func.isRequired,
   setRefundFromTx: PropTypes.func.isRequired,
+  setRefundLocal: PropTypes.func,
+  refundFile: PropTypes.object,
   // refundStx: PropTypes.func.isRequired,
 };
 

--- a/src/views/refund/steps/uploadRefundFile.js
+++ b/src/views/refund/steps/uploadRefundFile.js
@@ -77,7 +77,7 @@ class StyledUploadRefundFile extends React.Component {
       setRefundLocal(swapData);
       this.setState({ refundSet: true });
     } catch (error) {
-      console.log('error getting swapId: ', error.message);
+      console.log('uf.80 error getting swapId: ', error.message);
     }
   };
 

--- a/src/views/swap/index.js
+++ b/src/views/swap/index.js
@@ -4,6 +4,7 @@ import {
   completeSwap,
   setSwapInvoice,
   claimSwap,
+  continueSwap,
 } from '../../actions/swapActions';
 import Swap from './swap';
 
@@ -22,6 +23,8 @@ const mapDispatchToProps = dispatch => ({
   startSwap: (info, cb) => dispatch(startSwap(info, cb)),
   claimSwap: (nextStage, swapInfo, swapResponse, swapStatus) =>
     claimSwap(dispatch, nextStage, swapInfo, swapResponse, swapStatus),
+  continueSwap: (swapData, nextStage, cb) =>
+    dispatch(continueSwap(swapData, nextStage, cb)),
   // completeSwap: () => dispatch(completeReverseSwap()),
 });
 

--- a/src/views/swap/steps/sendTransaction.js
+++ b/src/views/swap/steps/sendTransaction.js
@@ -947,13 +947,20 @@ class SendTransaction extends React.Component {
 
   render() {
     // setAllowZeroConf
-    const {
-      classes,
-      swapInfo,
-      swapResponse,
-      swapStatus,
-      claimSwap,
-    } = this.props;
+    let { classes, swapInfo, swapResponse, swapStatus, claimSwap } = this.props;
+
+    if (window.location.href.includes('/swap?swapId=') && !swapInfo.base) {
+      try {
+        const swapId = window.location.href.split('?swapId=')[1];
+        if (!localStorage['lnswaps_' + swapId]) return;
+        const swapData = JSON.parse(localStorage['lnswaps_' + swapId]);
+        swapInfo = swapData.swapInfo;
+        // swapResponse = swapData.swapResponse;
+        // console.log('sendTransaction.959 swapInfo ', swapInfo, swapResponse);
+      } catch (error) {
+        console.log('st.961 error getting swapId: ', error.message);
+      }
+    }
 
     console.log(
       'sendtransaction.682 , ',

--- a/src/views/swap/steps/sendTransaction.js
+++ b/src/views/swap/steps/sendTransaction.js
@@ -1097,7 +1097,9 @@ class SendTransaction extends React.Component {
                 }}
                 // color={this.state.statusColor}
               >
-                {!this.state.txId && !swapStatus?.transaction?.id
+                {!this.state.txId &&
+                !swapStatus?.transaction?.id &&
+                !swapStatus?.message?.includes('Transaction is in mempool...')
                   ? `Send ${amountToLock} ${swapInfo.base}`
                   : null}
                 {swapResponse.bip21 &&
@@ -1105,7 +1107,8 @@ class SendTransaction extends React.Component {
                 swapStatus.message?.includes('Waiting')
                   ? ` to ${swapResponse.address}`
                   : null}
-                {this.state.txId && !swapStatus?.transaction?.id
+                {(this.state.txId && !swapStatus?.transaction?.id) ||
+                swapStatus?.message?.includes('Transaction is in mempool...')
                   ? `Pending confirmation of the ${amountToLock} ${swapInfo.base} sent`
                   : null}
                 {swapStatus?.transaction?.id &&
@@ -1177,7 +1180,8 @@ class SendTransaction extends React.Component {
               ref={this.ref}
               disabled={
                 (swapStatus.transaction && swapStatus.transaction.hex) ||
-                this.state.txId
+                this.state.txId ||
+                swapStatus?.message?.includes('Transaction is in mempool...')
               }
               onClick={() =>
                 swapInfo.base === 'STX'

--- a/src/views/swap/steps/sendTransaction.js
+++ b/src/views/swap/steps/sendTransaction.js
@@ -165,6 +165,9 @@ const SendTransactionStyles = theme => ({
 //   );
 // }
 
+function decideExplorer(txid) {
+  return txid.includes('0x') ? 'txid' : 'tx';
+}
 function createSTXPostCondition(principal, conditionCode, amount) {
   if (typeof principal === 'string') {
     principal = parsePrincipalString(principal);
@@ -1317,9 +1320,9 @@ class SendTransaction extends React.Component {
             <Button
               href={
                 swapStatus?.transaction?.id
-                  ? `${getExplorer(swapInfo.quote)}/tx/${
+                  ? `${getExplorer(swapInfo.quote)}/${decideExplorer(
                       swapStatus?.transaction?.id
-                    }`
+                    )}/${swapStatus?.transaction?.id}`
                   : this.state.explorerLink
               }
               // underline="none"

--- a/src/views/swap/swap.js
+++ b/src/views/swap/swap.js
@@ -34,7 +34,7 @@ class Swap extends Component {
   };
 
   componentWillUnmount = () => {
-    console.log('swap.37 componentWillUnmount ', this.props);
+    // console.log('swap.37 componentWillUnmount ', this.props);
     this.props.completeSwap();
   };
 
@@ -44,7 +44,7 @@ class Swap extends Component {
       const swapId = this.props?.location?.search.split('?swapId=')[1];
       console.log('swap.44 continue swapId ', swapId);
     } else if (!this.props.inSwapMode) {
-      console.log('swap.43 this.props.inSwapMode ', this.props);
+      // console.log('swap.43 this.props.inSwapMode ', this.props);
       navigation.navHome();
     }
   };

--- a/src/views/swap/swap.js
+++ b/src/views/swap/swap.js
@@ -34,11 +34,17 @@ class Swap extends Component {
   };
 
   componentWillUnmount = () => {
+    console.log('swap.37 componentWillUnmount ', this.props);
     this.props.completeSwap();
   };
 
   redirectIfLoggedOut = () => {
-    if (!this.props.inSwapMode) {
+    // check if continuing from local
+    if (this.props?.location?.search?.includes('?swapId=')) {
+      const swapId = this.props?.location?.search.split('?swapId=')[1];
+      console.log('swap.44 continue swapId ', swapId);
+    } else if (!this.props.inSwapMode) {
+      console.log('swap.43 this.props.inSwapMode ', this.props);
       navigation.navHome();
     }
   };
@@ -58,6 +64,7 @@ class Swap extends Component {
   };
 
   completeSwap = () => {
+    console.log('swap.61 completeSwap ');
     this.props.completeSwap();
 
     window.onbeforeunload = () => {};
@@ -69,7 +76,7 @@ class Swap extends Component {
   };
 
   render() {
-    const {
+    let {
       classes,
       webln,
       setSwapInvoice,
@@ -77,8 +84,32 @@ class Swap extends Component {
       swapResponse,
       swapStatus,
       claimSwap,
+      continueSwap,
     } = this.props;
-    // console.log('swap.js 74 ', swapInfo, swapStatus);
+    console.log('swap.js 74 ', swapInfo, swapStatus, continueSwap);
+    console.log('swap.js 90 ', this.props);
+
+    // update props if continuing swap
+    if (
+      this.props?.location?.search?.includes('?swapId=') &&
+      !swapInfo.type &&
+      !swapResponse
+    ) {
+      try {
+        if (!window.location.href.includes('?')) return;
+        const swapId = window.location.href.split('?swapId=')[1];
+        if (!localStorage['lnswaps_' + swapId]) return;
+        const swapData = JSON.parse(localStorage['lnswaps_' + swapId]);
+        swapInfo = swapData.swapInfo;
+        swapResponse = swapData.swapResponse;
+        console.log('swap.105 swapfromlocal ', swapInfo, swapResponse);
+        // swapStatus.message = swapData.status;
+        continueSwap(swapData.swapResponse);
+      } catch (error) {
+        console.log('swap.109 error getting swapId: ', error.message);
+      }
+    }
+
     return (
       <BackGround>
         <Prompt />
@@ -257,6 +288,7 @@ Swap.propTypes = {
   swapStatus: PropTypes.object.isRequired,
   inSwapMode: PropTypes.bool,
   claimSwap: PropTypes.func,
+  continueSwap: PropTypes.func,
 };
 
 export default injectSheet(styles)(Swap);

--- a/src/views/swap/swap.js
+++ b/src/views/swap/swap.js
@@ -68,7 +68,8 @@ class Swap extends Component {
     this.props.completeSwap();
 
     window.onbeforeunload = () => {};
-    window.location.reload();
+    // window.location.reload();
+    window.location.href = '/';
   };
 
   claimSwap = () => {
@@ -254,6 +255,7 @@ class Swap extends Component {
                     swapResponse={swapResponse}
                   />
                 )}
+                swapStatus={swapStatus}
               />
               <StepsWizard.Control
                 num={4}


### PR DESCRIPTION
Adds a new `continue` page where swap data are saved to localstorage and users are able to view previous swap data. 
Users can continue previous swaps directly from this list 
Users can refund failed swaps directly from this list.

There are some *limitations* especially around continuing right after calling final claim stx - if user leaves and tries to continue they'll get `claim stx` button again even though claimstx is ongoing. 

For most use cases, like users without refund files - this should help.
Users that had to leave the swap page and want to trigger final `claim` calls. they should be able to do it.